### PR TITLE
feat(bin): migrate to commander, remove yargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,24 +38,28 @@ npm install -g animego-dl # remove with: npm uninstall -g animego-dl
 ## Usage
 
 ```sh
-Usage: -d <download destination> -n <anime name>
+Usage: animego-dl [options] <anime name>
+
+CLI tool to download your favorite anime series.
+
+Arguments:
+  anime name                The name of anime series to download  [string] [required]
 
 Options:
-      --help        Show help                                          [boolean]
-      --version     Show version number                                [boolean]
-  -d, --directory   Source directory for your anime download [string] [required]
-  -n, --anime-name  The title of your desired anime to download [string] [required]
+  -V, --version             output the version number
+  -d, --directory <string>  the download directory for your anime  [string] [required]
+  -h, --help                display help for command
 ```
 
 **note**: if you installed the package globally, you can simply run:
 
 ```sh
-animego-dl -d <destination dir> -n <anime series name>`
+animego-dl -d <destination dir> '<anime series name>'`
 ```
 
 If you did not install globally, you can run from the root of the project's source directory:
 ```
-node .
+node bin -d <destination dir> '<anime series name>'`
 ```
 ---
 
@@ -63,9 +67,9 @@ node .
 > formatted (improvements to tool will be made in the near future).
 
 Anime title input examples:
-  * specify dub: `animego-dl -d '<destination dir>' -n 'Berserk dub'`
+  * specify dub: `animego-dl -d '<destination dir>' 'Berserk dub'`
     - no special characters, params, or dashes
-  * specify sub: `animego-dl -d '<destination dir>' -n 'sono bisque doll wa koi wo suru'`
+  * specify sub: `animego-dl -d '<destination dir>' 'sono bisque doll wa koi wo suru'`
     - please note we **do not** specify *dub* in the name -- this will be
       improved in the future
     - no special characters, params, or dashes

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,29 +1,36 @@
 #!/usr/bin/env node
 
-const yargs = require("yargs");
+const { Command } = require("commander");
 
 const AnimeDL = require("../lib/anime-dl");
 const checkExecutableSync = require("../lib/check-executable");
+const {
+  cliInput: { validateDirectoryLocation, validateAnimeName },
+} = require("../lib/utils");
 
-const cliOptions = yargs
-  .usage("Usage: -d <download destination> -n <anime name>")
-  .option("d", {
-    alias: "directory",
-    describe: "Source directory for your anime download",
-    type: "string",
-    demandOption: true,
-  })
-  .option("n", {
-    alias: "anime-name",
-    describe: "The title of your desired anime to download",
-    type: "string",
-    demandOption: true,
-  }).argv;
+const program = new Command()
+  .name("animego-dl")
+  .description("CLI tool to download your favorite anime series.")
+  .version("2.0.0")
+  .requiredOption(
+    "-d, --directory <string>",
+    "the download directory for your anime  [string] [required]",
+    validateDirectoryLocation
+  )
+  .argument(
+    "<anime name>",
+    "The name of anime series to download  [string] [required]",
+    validateAnimeName
+  );
 
-// check for 3rd-party executables existence
+const parsedCliOptions = program.parse();
+
 if (checkExecutableSync("yt-dlp")) {
-  // Initialize
-  AnimeDL(cliOptions)
+  const { directory } = parsedCliOptions.opts();
+  const [animeName] = parsedCliOptions.args;
+
+  // initialize
+  AnimeDL({ directory, animeName })
     .then((successMessage) => {
       console.log(successMessage);
       process.exit(0);

--- a/lib/utils/cli-input.js
+++ b/lib/utils/cli-input.js
@@ -1,0 +1,24 @@
+const { InvalidOptionArgumentError } = require("commander");
+
+const { isStringEmpty } = require("./general");
+
+const commanderEmptyArgValidator = (errorMessage) => (value) => {
+  if (isStringEmpty(value)) {
+    throw new InvalidOptionArgumentError(`\n${errorMessage}`);
+  }
+
+  return value;
+};
+
+const validateDirectoryLocation = commanderEmptyArgValidator(
+  "Please supply a valid directory location."
+);
+
+const validateAnimeName = commanderEmptyArgValidator(
+  "Please supply an Anime name."
+);
+
+module.exports = {
+  validateDirectoryLocation,
+  validateAnimeName,
+};

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,7 +1,9 @@
 const general = require("./general");
+const cliInput = require("./cli-input");
 const http = require("./http");
 
 module.exports = {
   general,
+  cliInput,
   http,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
-  "name": "gogoanime-dl-cli",
-  "version": "1.0.0",
+  "name": "animego-dl",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "gogoanime-dl-cli",
-      "version": "1.0.0",
+      "name": "animego-dl",
+      "version": "2.0.0",
       "license": "GPL-3.0",
       "dependencies": {
         "cheerio": "^1.0.0-rc.10",
-        "yargs": "^17.3.1"
+        "commander": "^9.0.0"
       },
       "bin": {
-        "anime-dl": "bin/index.js"
+        "animego-dl": "bin/index.js"
       },
       "devDependencies": {
         "mocha": "^9.1.4"
@@ -38,6 +38,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -46,6 +47,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -223,6 +225,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -233,6 +236,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -243,7 +247,16 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/commander": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+      "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -375,7 +388,8 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/entities": {
       "version": "2.2.0",
@@ -389,6 +403,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -466,6 +481,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -588,6 +604,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -910,6 +927,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -947,6 +965,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -960,6 +979,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -1036,6 +1056,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -1058,33 +1079,9 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
-      "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/yargs-unparser": {
@@ -1131,12 +1128,14 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
     },
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -1272,6 +1271,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -1282,6 +1282,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -1289,7 +1290,13 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "commander": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+      "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1379,7 +1386,8 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "entities": {
       "version": "2.2.0",
@@ -1389,7 +1397,8 @@
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "4.0.0",
@@ -1438,7 +1447,8 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "glob": {
       "version": "7.1.7",
@@ -1526,7 +1536,8 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
     },
     "is-glob": {
       "version": "4.0.3",
@@ -1758,7 +1769,8 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "safe-buffer": {
       "version": "5.2.1",
@@ -1779,6 +1791,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -1789,6 +1802,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -1841,6 +1855,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -1856,26 +1871,8 @@
     "y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
-    },
-    "yargs": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
-      "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
-      "requires": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
-      }
-    },
-    "yargs-parser": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA=="
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
     },
     "yargs-unparser": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     "cheerio": "^1.0.0-rc.10",
-    "yargs": "^17.3.1"
+    "commander": "^9.0.0"
   },
   "devDependencies": {
     "mocha": "^9.1.4"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->
* remove yargs package & added commander
* refactored entry point to use commander
* add util file for cli-input (commander) processing
* update readme: usage & command code snippets

## Related Issues

<!--- Please list all issues related to this PR: -->

- Resolves: #16

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Commander has a cleaner API, lots of community usage, and easier support for
positional arguments.  This new change also makes `animego-dl`'s operation
clearer.

## How To Test It?

<!--- Please provide context for reviewers about how to test the PR

For example:
 - Environment
 - Node Version (or docker version if applicable)
 - Steps to reach view / reproduce issue
-->

**Environment:** `Linux`, `MacOS`
**Node Version:** `v16.13.1`
**YT-DLP Version:** `2021.12.27`

**Steps**:
<!-- Steps to test -->
1. Run command with `node bin` - observe help command
2. Run command with empty dir arg: `node bin -d ''` - observe error output
3. Run command with valid dir arg, no anime name: `node bin -d tmp`
    - observe error output for missing anime name
4. Run command with valid valid arg: `node bin -d tmp 'berserk dub'`
    - observe download initiation (`ctrl-c` abort download)

## Visual reference

<!---
Please include screenshots, gifs or recordings. If your changes are not visual, write "No visual changes made".

For example: if this is a cli UI fix, provide relevant screenshots or recordings
-->
No visual changes

## Checklist

<!---
Go over all the following points and:
- put an `x` in all the boxes that apply. ([x])
- put n/a in all the boxes that do not apply. ([n/a])
Please be sure to add the name of the device you tested and whether it was a simulator or physical device.

For example:
- [x] I have tested on a supported environment: Linux
- [x] I have tested using the project's Node version: `v16.13.1`
- [n/a] I have added tests to cover my changes.
- [n/a] I have updated the documentation accordingly.
-->

- [x] I have tested on a supported environment: Linux
- [x] I have tested using the project's Node version: `v16.13.1`
- [ ] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
