### PR TITLE
refactor(anime-dl): remove unused imports, clean fn names

### DIFF
--- a/lib/anime-dl/index.js
+++ b/lib/anime-dl/index.js
@@ -4,17 +4,16 @@ const path = require("path");
 const cheerio = require("cheerio");
 
 const {
-  general: { isStringEmpty, compose, safeJSONParse },
+  general: { isStringEmpty },
   http: { httpGet, getOriginHeadersWithLocation },
 } = require("../utils");
 
 const {
-  queryEpisodeDetailsPageForVideoSrc,
   extractVideoMetadataFromDetailsPage,
   getEpisodeRangesFromDetailsPage,
-  decryptVideoSourceUrl,
   downloadAndSaveVideo,
-  getTargetVideoQualityFromSources,
+  getSourcesAndDecrypt,
+  parseSourcesAndGetVideo,
 } = require("./processing");
 
 const Constants = {
@@ -34,16 +33,6 @@ const normalizeInputAnimeName = (animeName) => {
 
 const createEpisodeFilename = (index) =>
   `episode-${index < 10 ? "0" + index : index}`;
-
-const getVideoSrcAndDecrypt = compose(
-  decryptVideoSourceUrl,
-  queryEpisodeDetailsPageForVideoSrc
-);
-
-const parseSourceListAndGetVideo = compose(
-  getTargetVideoQualityFromSources,
-  safeJSONParse
-);
 
 module.exports = async function initialize(cliOptions) {
   const saveLocation = cliOptions.directory;
@@ -78,20 +67,14 @@ module.exports = async function initialize(cliOptions) {
   process.chdir(seriesTargetLocation);
 
   for (let i = 0; i < episodeRanges.length; i++) {
-    const currentRangeStart = episodeRanges[i].start;
-    const currentRangeEnd = episodeRanges[i].end;
+    const { start: currentRangeStart, end: currentRangeEnd } = episodeRanges[i];
 
     for (let j = currentRangeStart; j <= currentRangeEnd; j++) {
+      const episodeUrl = `${BASE_URL}${normalizedAnimeName}-episode-${j}`;
+      const episodePage = await httpGet(episodeUrl);
+      const decryptedVideoSources = await getSourcesAndDecrypt(episodePage);
+      const videoSourceUrl = parseSourcesAndGetVideo(decryptedVideoSources);
       const videoName = createEpisodeFilename(j);
-      const episodeUrl = `${BASE_URL}${normalizedAnimeName}-episode-${j}`
-      const episodeDetailsPageHTML = await httpGet(episodeUrl);
-      const decryptedJSONVideoSources = await getVideoSrcAndDecrypt(
-        episodeDetailsPageHTML
-      );
-
-      const videoSourceUrl = parseSourceListAndGetVideo(
-        decryptedJSONVideoSources
-      );
 
       if (videoSourceUrl) {
         console.info(`Now downloading: ${episodeUrl}\n`);

--- a/lib/anime-dl/processing.js
+++ b/lib/anime-dl/processing.js
@@ -5,8 +5,8 @@ const crypto = require("crypto");
 const cheerio = require("cheerio");
 
 const {
-  general: { compose, stringToNum, removeMatchedPattern },
-  http: { httpGet, getOriginHeadersWithLocation, getJSON },
+  general: { compose, stringToNum, removeMatchedPattern, safeJSONParse },
+  http: { httpGet },
 } = require("../utils");
 
 const stripNewlinesAndSpacesToNum = compose(
@@ -141,11 +141,20 @@ const getTargetVideoQualityFromSources = (
   return defaultVideoRendition.file;
 };
 
+const getSourcesAndDecrypt = compose(
+  decryptVideoSourceUrl,
+  queryEpisodeDetailsPageForVideoSrc
+);
+
+const parseSourcesAndGetVideo = compose(
+  getTargetVideoQualityFromSources,
+  safeJSONParse
+);
+
 module.exports = {
-  queryEpisodeDetailsPageForVideoSrc,
   extractVideoMetadataFromDetailsPage,
   getEpisodeRangesFromDetailsPage,
   downloadAndSaveVideo,
-  decryptVideoSourceUrl,
-  getTargetVideoQualityFromSources,
+  getSourcesAndDecrypt,
+  parseSourcesAndGetVideo,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->
We had some unused import names, now they're gone ... gonna miss em
when they're gone :3

Also, fn names were a little long, cleaned them up a little.  Oo! And,
exported composed logic for decrypting video sources and parsing them --
this cleans the exports/imports & exposes only what's needed.


## Related Issues

<!--- Please list all issues related to this PR: -->

- [#1](#1)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Cleans imports/exports, and removes redundancy in function names.

## How To Test It?

<!--- Please provide context for reviewers about how to test the PR

For example:
 - Environment
 - Node Version (or docker version if applicable)
 - Steps to reach view / reproduce issue
-->

**Environment:** Mac, Linux
**Node Version:** `v16.13.1`
**YT-DLP Version:** `2021.12.27`

**Steps**:
<!-- Steps to test -->
* Ensure anime downloads with no issue (any title fine).

## Visual reference

<!---
Please include screenshots, gifs or recordings. If your changes are not visual, write "No visual changes made".

For example: if this is a cli UI fix, provide relevant screenshots or recordings
-->
n/a

## Checklist

<!---
Go over all the following points and:
- put an `x` in all the boxes that apply. ([x])
- put n/a in all the boxes that do not apply. ([n/a])
Please be sure to add the name of the device you tested and whether it was a simulator or physical device.

For example:
- [x] I have tested on a supported environment: Linux
- [x] I have tested using the project's Node version: `v16.13.1`
- [n/a] I have added tests to cover my changes.
- [n/a] I have updated the documentation accordingly.
-->

- [x] I have tested on a supported environment: MacOS
- [x] I have tested using the project's Node version: `v16.13.1`
- [n/a] I have added tests to cover my changes.
- [n/a] I have updated the documentation accordingly.
