### PR TITLE
refactor(anime-dl): better error handling/processing

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -32,8 +32,8 @@ const [animeName] = parsedCliOptions.args;
 if (checkExecutableSync("yt-dlp")) {
   // initialize
   AnimeDL({ directory, animeName })
-    .then((successMessage) => {
-      console.log(successMessage);
+    .then((message) => {
+      console.log(message);
       process.exit(0);
     })
     .catch((error) => {

--- a/lib/anime-dl/locales.ts
+++ b/lib/anime-dl/locales.ts
@@ -1,0 +1,19 @@
+const errors = {
+  detailsPageProcessing:
+    "Oops! Failed to scrape for the title's details page.  Either the title wasn't found, or something went wrong during initial metadata processing.  Please check your input title's name for errors.",
+  downloadAndSave: "No video source was supplied!",
+};
+
+export default {
+  errors,
+  createEpisodeFilename: (episodeCount: number) =>
+    `episode-${episodeCount < 10 ? "0" + episodeCount : episodeCount}`,
+  generateSeriesBaseUrl: (baseUrl: string, normalizedTitle: string) =>
+    `${baseUrl}category/${normalizedTitle}`,
+  generateEpisodeUrl: (
+    baseUrl: string,
+    normalizedTitle: string,
+    episodeCount: number
+  ) => `${baseUrl}${normalizedTitle}-episode-${episodeCount}`,
+  successfulDownload: "\nYour title has been downloaded!  Enjoy!",
+};

--- a/lib/anime-dl/processing.ts
+++ b/lib/anime-dl/processing.ts
@@ -4,6 +4,9 @@ import { createCipheriv } from "crypto";
 import cheerio from "cheerio";
 
 import utils from "../utils";
+import { GOGO_ENCRYPT_AJAX } from "../constants/urls";
+
+import locales from "./locales";
 
 const {
   general: { compose, stringToNum, removeMatchedPattern, safeJSONParse },
@@ -102,7 +105,7 @@ const getEpisodeRangesFromDetailsPage = (pageHTML: string) => {
 const downloadAndSaveVideo = (videoSourceUrl: string, videoName: string) =>
   new Promise((resolve, reject) => {
     if (!videoSourceUrl) {
-      return reject("Something went wrong: no video source was supplied!");
+      return reject(locales.errors.downloadAndSave);
     }
 
     try {
@@ -115,19 +118,14 @@ const downloadAndSaveVideo = (videoSourceUrl: string, videoName: string) =>
       ytDl.stdout.on("data", (buf) => console.log(buf.toString("utf8")));
       ytDl.on("close", reject);
       ytDl.on("exit", resolve);
-    } catch (e) {
-      // @ts-ignore
-      throw new Error(e);
+    } catch (err) {
+      throw err;
     }
   });
 
 const decryptVideoSourceUrl = async (encryptedSourceUrl: string) => {
   try {
-    if (!encryptedSourceUrl) {
-      throw new Error("Failed to retrieve video url from series details page!");
-    }
-
-    const ajaxEndpoint = "https://gogoplay.io/encrypt-ajax.php";
+    const ajaxEndpoint = GOGO_ENCRYPT_AJAX;
     const secret = Buffer.from(
       "3235373436353338353932393338333936373634363632383739383333323838",
       "hex"
@@ -155,8 +153,8 @@ const decryptVideoSourceUrl = async (encryptedSourceUrl: string) => {
     }
 
     return null;
-  } catch (error) {
-    throw Error(`Oops! Something went wrong: ${error}`);
+  } catch (err) {
+    throw err;
   }
 };
 
@@ -175,11 +173,11 @@ const getTargetVideoQualityFromSources = (
 
 const getSourcesAndDecrypt = compose(
   decryptVideoSourceUrl,
-  queryEpisodeDetailsPageForVideoSrc
+  queryEpisodeDetailsPageForVideoSrc // TODO: run control flow piping (ignore decryptVideoSourceUrl if empty src)
 );
 
 const parseSourcesAndGetVideo = compose(
-  getTargetVideoQualityFromSources,
+  getTargetVideoQualityFromSources, // TODO: run control flow piping (ignore this if empty parse result)
   safeJSONParse
 );
 

--- a/lib/constants/urls.ts
+++ b/lib/constants/urls.ts
@@ -1,0 +1,3 @@
+// Gogo Urls
+export const GOGO_ROOT = "https://gogoanime.cm";
+export const GOGO_ENCRYPT_AJAX = "https://gogoplay.io/encrypt-ajax.php";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->
* handle errors better (delegate thrown errors to initial caller)
  - catch block in bin entry

* move consts to constants file
* create anime-dl/locales file for strings & generated strings - avoid logic
  pollution & keeps things constant

## Related Issues

<!--- Please list all issues related to this PR: -->

- [#18](#18)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Cleaner errors, better reasoning.  Moves constants to files for easier & more
transparent updating.

## How To Test It?
<!--- Please provide context for reviewers about how to test the PR

For example:
 - Environment
 - Node Version (or docker version if applicable)
 - Steps to reach view / reproduce issue
-->

* Environment: `Linux`, `MacOS` <!--Linux, MacOS, Windows, Docker-->
* Node Version: `v16.13.1` <!--node version-->
* YT-DLP Version: `2021.12.27` <!--yt-dlp version-->

**Steps**:
<!-- Steps on how to test -->

## Visual reference

<!---
Please include screenshots, gifs or recordings. If your changes are not visual, write "No visual changes made".

For example: if this is a cli UI fix, provide relevant screenshots or recordings
-->
No visual changes made

## Checklist

<!---
Go over all the following points and:
- put an `x` in all the boxes that apply. ([x])
- put n/a in all the boxes that do not apply. ([n/a])
Please be sure to add the name of the device you tested and whether it was a simulator or physical device.

For example:
- [x] I have tested on a supported environment: Linux
- [x] I have tested using the project's Node version: `v16.13.1`
- [n/a] I have added tests to cover my changes.
- [n/a] I have updated the documentation accordingly.
-->

- [x] I have tested on a supported environment: Linux
- [x] I have tested using the project's Node version: `v16.13.1`
- [n/a] I have added tests to cover my changes.
- [n/a] I have updated the documentation accordingly.
