### PR TITLE
docs(readme): add new gh highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ https://user-images.githubusercontent.com/11083531/174728256-b21e613e-a148-46f6-
 
 ## Dependencies
 
-> :warning: Sorry Windows users, things have been tested on Linux & MacOS only.  Support
+> [!NOTE]
+> Sorry Windows users, things have been tested on Linux & MacOS only.  Support
 > might be coming soon.
 
 First, make sure you have the following installed on your machine:
@@ -118,7 +119,8 @@ animego-dl -d
 
 Next, search & select the episode you'd like to download via the cli.  Enjoy!
 
-> :warning: The tool will download to your current working directory (where you
+> [!NOTE]
+> The tool will download to your current working directory (where you
 > ran the command), and under a directory named `animego-dl` -- options to
 > choose your destination directory will be added soon!
 
@@ -126,7 +128,8 @@ Next, search & select the episode you'd like to download via the cli.  Enjoy!
 
 ## Docker
 
-> :warning: The image requires a connection to your Pulseaudio & Xorg servers,
+> [!WARNING]
+> The image requires a connection to your Pulseaudio & Xorg servers,
 > so make sure you are running an Xdisplay & have Pulseaudio (or pipewire) on
 > your host machine.  If you're running Ubuntu, PopOS, or some debian
 > derivative, you should be fine!
@@ -200,7 +203,8 @@ To run local tests: `npm run test`
 
 To run tests in watch mode: `npm run test:watch`
 
-> :warning: Tests are few and far between at the moment.  In fact, no test
+> [!NOTE]
+> Tests are few and far between at the moment.  In fact, no test
 > suites are live at this time - 2/13/22.
 
 ## Disclaimer


### PR DESCRIPTION



## Description

<!--- Describe your changes in detail -->
This adds quote highlights to the readme -- GH added colored indicators to markdown blockquotes!

## Related Issues

<!--- Please list all issues related to this PR: -->

- [#1](#1)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Pretty README

## How To Test It?
<!--- Please provide context for reviewers about how to test the PR

For example:
 - Environment
 - Node Version (or docker version if applicable)
 - Steps to reach view / reproduce issue
-->

* Environment: `Linux` <!--Linux, MacOS, Windows, Docker-->
* Node Version: `v16.13.1` <!--node version-->
* YT-DLP Version: `2021.12.27` <!--yt-dlp version-->

**Steps**:
<!-- Steps on how to test -->

## Visual reference

<!---
Please include screenshots, gifs or recordings. If your changes are not visual, write "No visual changes made".

For example: if this is a cli UI fix, provide relevant screenshots or recordings
-->

## Checklist

<!---
Go over all the following points and:
- put an `x` in all the boxes that apply. ([x])
- put n/a in all the boxes that do not apply. ([n/a])
Please be sure to add the name of the device you tested and whether it was a simulator or physical device.

For example:
- [x] I have tested on a supported environment: Linux
- [x] I have tested using the project's Node version: `v16.13.1`
- [n/a] I have added tests to cover my changes.
- [n/a] I have updated the documentation accordingly.
-->

- [ ] I have tested on a supported environment: ENTER_ENV_HERE - MacOS, Linux
- [ ] I have tested using the project's Node version: `v16.13.1`
- [ ] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
